### PR TITLE
Updating version requirements to ruby 3.4 and faraday 2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.4
   NewCops: enable
   Exclude:
     - 'spec/**/*'
@@ -11,11 +11,17 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
+Gemspec/RequireMFA:
+  Enabled: false
+
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 23
+  Max: 25
 
 Metrics/MethodLength:
   Max: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.3 (13/01/2026)
+---------
+
+- Updating version requirements for Ruby (2.5 -> 3.4.8) and Faraday (1 -> 2)
+- Updating the code to reflect changes in Ruby and Faraday gem.
+
 1.0.2 (06/07/2020)
 ---------
 

--- a/govuk-pay-ruby-client.gemspec
+++ b/govuk-pay-ruby-client.gemspec
@@ -22,13 +22,15 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.4.8')
 
-  spec.add_runtime_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'base64', '~> 0.2.0'
+  spec.add_development_dependency 'bundler', '~> 4.0.3'
+  spec.add_development_dependency 'ostruct', '~> 0.6.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'rubocop', '~> 0.80'
+  spec.add_development_dependency 'rubocop', '~> 1.60'
   spec.add_development_dependency 'simplecov', '~> 0.18'
 end

--- a/lib/payments_api/errors.rb
+++ b/lib/payments_api/errors.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'errors'
-
 module PaymentsApi
   module Errors
     def raise_error!(response_body, status_code)

--- a/lib/payments_api/http_client.rb
+++ b/lib/payments_api/http_client.rb
@@ -59,7 +59,7 @@ module PaymentsApi
 
     def connection
       Faraday.new(url: config.api_root) do |conn|
-        conn.authorization(:Bearer, config.api_key)
+        conn.request(:authorization, 'Bearer', config.api_key)
 
         conn.response(:logger, options.fetch(:logger, config.logger), bodies: false) do |logger|
           logger.filter(/(Authorization:) "(Bearer .*)"/, '\1[REDACTED]')

--- a/lib/payments_api/responses/payment_result.rb
+++ b/lib/payments_api/responses/payment_result.rb
@@ -48,11 +48,11 @@ module PaymentsApi
       end
 
       def status
-        state.dig('status')
+        state['status']
       end
 
       def finished?
-        !!state.dig('finished')
+        !!state['finished']
       end
 
       def success?

--- a/lib/payments_api/traits/api_request.rb
+++ b/lib/payments_api/traits/api_request.rb
@@ -3,7 +3,7 @@
 module PaymentsApi
   module Traits
     module ApiRequest
-      #:nocov:
+      # :nocov:
       def call
         raise 'implement in subclasses'
       end
@@ -11,7 +11,7 @@ module PaymentsApi
       def endpoint
         raise 'implement in subclasses'
       end
-      #:nocov:
+      # :nocov:
 
       private
 

--- a/lib/payments_api/version.rb
+++ b/lib/payments_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PaymentsApi
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/spec/payments_api/requests/create_card_payment_spec.rb
+++ b/spec/payments_api/requests/create_card_payment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe PaymentsApi::Requests::CreateCardPayment do
-  subject { described_class.new(args) }
+  subject { described_class.new(**args) }
 
   let(:http_client) { instance_double(PaymentsApi::HttpClient, post: {}) }
 

--- a/spec/payments_api/requests/get_card_payment_spec.rb
+++ b/spec/payments_api/requests/get_card_payment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe PaymentsApi::Requests::GetCardPayment do
-  subject { described_class.new(args) }
+  subject { described_class.new(**args) }
 
   let(:http_client) { instance_double(PaymentsApi::HttpClient, get: {}) }
 


### PR DESCRIPTION
## Changes 
  - Ruby: 2.5.0 → 3.4.8 - Upgrade to latest Ruby version
  - Faraday: ~> 1.0 → ~> 2.0 - Update HTTP client library
  - Bundler: ~> 1.17 → ~> 4.0.3 - Update to bundler 4
  - Rubocop: ~> 0.80 → ~> 1.60 - Update linter to support Ruby 3.4
  - Added base64 & ostruct - Required in Ruby 3.4+ (removed from stdlib)

###  Code Changes

  - http_client.rb:62 - Changed conn.authorization() to conn.request(:authorization) - Faraday 2.x breaking change
  - errors.rb:3 - Removed self-referential require_relative 'errors' - Lint violation
  - payment_result.rb:51,55 - Changed .dig('key') to ['key'] - Simpler syntax for single-level hash access
  - api_request.rb:6,14 - Fixed comment spacing #:nocov: → # :nocov: - Style fix
